### PR TITLE
stop using deprecated datetime.utcnow()

### DIFF
--- a/pytest_docker_compose/plugin.py
+++ b/pytest_docker_compose/plugin.py
@@ -1,6 +1,6 @@
 import os.path
 import warnings
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -222,7 +222,7 @@ class DockerComposePlugin:
 
         @pytest.fixture(scope=scope)  # type: ignore
         def scoped_containers_fixture(docker_project: DockerClient, request):
-            now = datetime.utcnow()
+            now = datetime.now(timezone.utc)
             if not request.config.getoption("--use-running-containers"):
                 if any(
                     (


### PR DESCRIPTION
Deprecated since python 3.12. The suggested API seems as having been available since 3.2 at least.