### PR TITLE
fix: support latest version of pytest 8

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
+        pytest-version: ['7', '8']
     steps:
     - name: Check out repository
       uses: actions/checkout@v4
@@ -30,6 +31,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: uv sync
+    - name: Install pytest ${{ matrix.pytest-version }}
+      run: uv pip install "pytest>=${{ matrix.pytest-version }},<$(( ${{ matrix.pytest-version }} + 1 ))"
     - name: Run tests
       run: uv run pytest
     # NOTE: publishing to test repository is disabled until I figure out a way to do it reliably

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 ]
 
 [project.entry-points.pytest11]
-docker_compose = "pytest_docker_compose.plugin:plugin"
+docker_compose = "pytest_docker_compose.plugin"
 
 [project.urls]
 repository="https://github.com/radusuciu/pytest-docker-compose-v2"
@@ -56,6 +56,7 @@ dev = [
     "requests>=2.32.5",
     "tox>=4.30.3",
     "tox-uv>=1.28.1",
+    "pytest>=8.4.2,<9",
 ]
 
 [tool.hatch.version]

--- a/pytest_docker_compose/plugin.py
+++ b/pytest_docker_compose/plugin.py
@@ -276,6 +276,14 @@ class DockerComposePlugin:
 
 plugin = DockerComposePlugin()
 
+# Expose hooks and fixtures at module level for pytest 8 compatibility
+pytest_addoption = plugin.pytest_addoption
+docker_project = plugin.docker_project
+function_scoped_container_getter = plugin.function_scoped_container_getter
+class_scoped_container_getter = plugin.class_scoped_container_getter
+module_scoped_container_getter = plugin.module_scoped_container_getter
+session_scoped_container_getter = plugin.session_scoped_container_getter
+
 
 class ContainerGetter:
     """

--- a/uv.lock
+++ b/uv.lock
@@ -770,6 +770,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
 name = "pyproject-api"
 version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -803,7 +812,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "7.4.4"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -812,11 +821,12 @@ dependencies = [
     { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/1f/9d8e98e4133ffb16c90f3b405c43e38d3abb715bb5d7a63a5a684f7e46a3/pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280", size = 1357116, upload-time = "2023-12-31T12:00:18.035Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/ff/f6e8b8f39e08547faece4bd80f89d5a8de68a38b2d179cc1c4490ffa3286/pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8", size = 325287, upload-time = "2023-12-31T12:00:13.963Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
 ]
 
 [[package]]
@@ -834,6 +844,7 @@ dev = [
     { name = "git-cliff" },
     { name = "mypy" },
     { name = "psycopg2-binary" },
+    { name = "pytest" },
     { name = "requests" },
     { name = "ruff" },
     { name = "tox", version = "4.30.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -856,6 +867,7 @@ dev = [
     { name = "git-cliff", specifier = ">=2.0.4" },
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "psycopg2-binary", specifier = ">=2.9.9" },
+    { name = "pytest", specifier = ">=8.4.2,<9" },
     { name = "requests", specifier = ">=2.32.5" },
     { name = "ruff", specifier = ">=0.14.9" },
     { name = "tox", specifier = ">=4.30.3" },


### PR DESCRIPTION
I named this branch with a "feat-" prefix since I forgot that pytest 8 was supported, and that that was broken as of 8.3.3 (see: https://github.com/pytest-dev/pytest/discussions/12851).

Also adding tests for both pytest 7 and 8 to CI and adding back the pytest 8 dev dependency.