### PR TITLE
feat: expand support to pytest 9

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,12 +16,12 @@ jobs:
       id-token: write
     steps:
     - name: Check out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Set up uv
       uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
-        python-version: '3.11'
+        python-version: '3.13'
 
     - name: Install dependencies
       run: uv sync

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
         pytest-version: ['7', '8', '9']
     steps:
     - name: Check out repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       # needed because we use git describe to get a bumpver compatible GITHASH containing version
       # alternatively can look at using HEXHASH instead. Note that these are purposefully not
       # documented in the bumpver project, see issues/PRs for more info.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,10 +3,9 @@ name: Test
 on:
   push:
     branches:
-      - '*'
+      - main
+      - develop
   pull_request:
-    branches:
-      - '*'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,11 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         pytest-version: ['7', '8', '9']
-        exclude:
-          - python-version: '3.9'
-            pytest-version: '9'
     steps:
     - name: Check out repository
       uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         pytest-version: ['7', '8', '9']

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,10 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
-        pytest-version: ['7', '8']
+        pytest-version: ['7', '8', '9']
+        exclude:
+          - python-version: '3.9'
+            pytest-version: '9'
     steps:
     - name: Check out repository
       uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To interact with Docker containers in your tests, use the following fixtures. Th
 
 ### `function_scoped_container_getter`
 
-An object that fetches containers of the Docker `compose.container.Container` objects running during the test. The containers are fetched using `function_scoped_container_getter.get('service_name')` These containers each have an extra attribute called `network_info` added to them. This attribute has a list of `pytest_docker_compose.NetworkInfo` objects.
+An object that fetches containers of the Docker `python_on_whales.Container` objects running during the test. The containers are fetched using `function_scoped_container_getter.get('service_name')` These containers each have an extra attribute called `network_info` added to them. This attribute has a list of `pytest_docker_compose.NetworkInfo` objects.
 
 This information can be used to configure API clients and other objects that will connect to services exposed by the Docker containers in your tests.
 
@@ -59,12 +59,12 @@ This information can be used to configure API clients and other objects that wil
 
 ### `docker_project`
 
-The `compose.project.Project` object that the containers are built from.
+The `python_on_whales.DockerClient` object that the containers are built from.
 This fixture is generally only used internally by the plugin.
 
 ### Wider scoped fixtures
 
-To use the following fixtures please read [Use wider scoped fixtures](#use-wider-scope-fixtures)
+To use the following fixtures please read [Use wider scoped fixtures](#use-wider-scoped-fixtures)
 
 - `class_scoped_container_getter`: Similar to `function_scoped_container_getter` just with a wider scope.
 - `module_scoped_container_getter`: Similar to `function_scoped_container_getter` just with a wider scope.
@@ -132,7 +132,7 @@ pytest --use-running-containers
 
 With this flag, `pytest-docker-compose` checks that all containers are running
 during the project creation. If they are not running a warning is given and
-they are spun up anyways. They are then used for all the tests and NOT TORE
+they are spun up anyways. They are then used for all the tests and NOT TORN
 DOWN afterwards.
 
 This mode is best used in combination with the `--docker-compose-no-build` flag since the newly build containers won't be used anyways. like so:
@@ -181,7 +181,7 @@ addopts = --docker-compose=/path/to/docker-compose.yml
 
 The option will be ignored for tests that do not use this plugin.
 
-See [Configuration Options](https://docs.pytest.org/en/latest/customize.html#adding-default-options) for more information on using configuration
+See [Configuration Options](https://docs.pytest.org/en/stable/reference/customize.html#adding-default-options) for more information on using configuration
 files to modify pytest behavior.
 
 ### Remove volumes after tests

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Make sure you have [Docker](https://docs.docker.com/get-docker/) installed.
 
 This plugin is automatically tested against the following software:
 
-- Python 3.9, 3.10, 3.11 and 3.12
-- pytest 7
+- Python 3.10, 3.11, 3.12, 3.13 and 3.14
+- pytest 7, 8 and 9
 
 **NOTE**: This plugin is **not** compatible with Python 2.
 
@@ -33,16 +33,13 @@ pip install pytest-docker-compose-v2
 
 ## Usage
 
-For performance reasons, the plugin is not enabled by default, so you must activate it manually in the tests that use it:
+The plugin is automatically enabled when installed. To disable it for specific test runs, use:
 
-```python
-pytest_plugins = ["docker_compose"]
+```shell
+pytest -p no:docker_compose
 ```
 
-
-See [Installing and Using Plugins](https://docs.pytest.org/en/latest/plugins.html#requiring-loading-plugins-in-a-test-module-or-conftest-file) for more information.
-
-To interact with Docker containers in your tests, use the following fixtures, these fixtures tell docker-compose to start all the services and then they can fetch the associated containers for use in a test:
+To interact with Docker containers in your tests, use the following fixtures. These fixtures tell docker-compose to start all the services and then fetch the associated containers for use in a test:
 
 ### `function_scoped_container_getter`
 
@@ -89,8 +86,6 @@ import requests
 from urllib.parse import urljoin
 from urllib3.util.retry import Retry
 from requests.adapters import HTTPAdapter
-
-pytest_plugins = ["docker_compose"]
 
 # Invoking this fixture: 'function_scoped_container_getter' starts all services
 @pytest.fixture(scope="function")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     {name = "Phoenix Zerin"},
 ]
 dependencies = [
-    "pytest>=7.2.2,<9",
+    "pytest>=7.2.2,<10",
     "python-on-whales>=0.69.0,<1"
 ]
 requires-python = ">=3.9"
@@ -56,7 +56,7 @@ dev = [
     "requests>=2.32.5",
     "tox>=4.30.3",
     "tox-uv>=1.28.1",
-    "pytest>=8.4.2,<9",
+    "pytest>=8,<10",
 ]
 
 [tool.hatch.version]
@@ -100,12 +100,13 @@ push = false
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py{39,310,311,312}-pytest{7,8}
+envlist = py{39,310,311,312}-pytest{7,8,9}
 
 [testenv]
 deps =
     pytest7: pytest>=7,<8
     pytest8: pytest>=8,<9
+    pytest9: pytest>=9,<10
     python_on_whales
     ruff
     mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "pytest>=7.2.2,<10",
     "python-on-whales>=0.69.0,<1"
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme = "README.md"
 license = {text = "Apache"}
 keywords = [
@@ -26,10 +26,11 @@ classifiers = [
   "Framework :: Pytest",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",
 ]
@@ -100,7 +101,7 @@ push = false
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py{39,310,311,312}-pytest{7,8,9}
+envlist = py{310,311,312,313,314}-pytest{7,8,9}
 
 [testenv]
 deps =

--- a/pytest_docker_compose/plugin.py
+++ b/pytest_docker_compose/plugin.py
@@ -92,7 +92,7 @@ class DockerComposePlugin:
         """
         Adds custom options to the ``pytest`` command.
 
-        https://docs.pytest.org/en/latest/writing_plugins.html#_pytest.hookspec.pytest_addoption
+        https://docs.pytest.org/en/latest/how-to/writing_plugins.html#testing-plugins
         """
         group = parser.getgroup("docker_compose", "integration tests")
 

--- a/pytest_docker_compose/plugin.py
+++ b/pytest_docker_compose/plugin.py
@@ -92,7 +92,7 @@ class DockerComposePlugin:
         """
         Adds custom options to the ``pytest`` command.
 
-        https://docs.pytest.org/en/latest/how-to/writing_plugins.html#testing-plugins
+        https://docs.pytest.org/en/stable/reference/reference.html#pytest.hookspec.pytest_addoption
         """
         group = parser.getgroup("docker_compose", "integration tests")
 

--- a/tests/pytest_docker_compose_tests/test_function_scoping_fixtures.py
+++ b/tests/pytest_docker_compose_tests/test_function_scoping_fixtures.py
@@ -5,8 +5,6 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-pytest_plugins = ["docker_compose"]
-
 
 @pytest.fixture(scope="function")
 def wait_for_api(function_scoped_container_getter):

--- a/tests/pytest_docker_compose_tests/test_module_scoping_fixtures.py
+++ b/tests/pytest_docker_compose_tests/test_module_scoping_fixtures.py
@@ -6,8 +6,6 @@ from requests.adapters import HTTPAdapter
 
 import pytest
 
-pytest_plugins = ["docker_compose"]
-
 
 @pytest.fixture(scope="module")
 def wait_for_api(module_scoped_container_getter):

--- a/tests/pytest_docker_compose_tests/test_multiple_compose_files.py
+++ b/tests/pytest_docker_compose_tests/test_multiple_compose_files.py
@@ -6,8 +6,6 @@ from requests.adapters import HTTPAdapter
 
 import pytest
 
-pytest_plugins = ["docker_compose"]
-
 
 @pytest.fixture(scope="module")
 def wait_for_api(module_scoped_container_getter):

--- a/tests/pytest_docker_compose_tests/test_wrong_scoping.py
+++ b/tests/pytest_docker_compose_tests/test_wrong_scoping.py
@@ -1,7 +1,5 @@
 import pytest
 
-pytest_plugins = ["docker_compose"]
-
 
 @pytest.mark.should_fail
 def test_read_all_module(module_scoped_container_getter):

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.10'",
@@ -856,7 +856,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "pytest", specifier = ">=7.2.2,<9" },
+    { name = "pytest", specifier = ">=7.2.2,<10" },
     { name = "python-on-whales", specifier = ">=0.69.0,<1" },
 ]
 
@@ -867,7 +867,7 @@ dev = [
     { name = "git-cliff", specifier = ">=2.0.4" },
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "psycopg2-binary", specifier = ">=2.9.9" },
-    { name = "pytest", specifier = ">=8.4.2,<9" },
+    { name = "pytest", specifier = ">=8,<10" },
     { name = "requests", specifier = ">=2.32.5" },
     { name = "ruff", specifier = ">=0.14.9" },
     { name = "tox", specifier = ">=4.30.3" },


### PR DESCRIPTION
- adds explicit supoprt and testing for pytest 9
- updates README to reflect the fact that the plugin is made available via `pytest11`
- dropped support for python 3.9 and added support for 3.13 and 3.14